### PR TITLE
sync rocHPL commits for ROCm 6.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ foreach(i ${rochpl_device_source})
 endforeach()
 
 # HIP flags workaround while target_compile_options does not work
-list(APPEND HIP_HIPCC_FLAGS "-Wno-unused-command-line-argument -fPIE")
+list(APPEND HIP_HIPCC_FLAGS "-Wno-unused-command-line-argument -fPIE -fopenmp")
 list(APPEND CMAKE_HOST_FLAGS "")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,17 +101,21 @@ else()
   list(APPEND CMAKE_HOST_FLAGS "-O3;-march=native")
 endif()
 
-
-# Availability of rocm_check_target_ids command assures that we can also build
-# for gfx90a target
-if(COMMAND rocm_check_target_ids)
-  set(DEFAULT_AMDGPU_TARGETS "gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx908:xnack+;gfx90a:xnack-;gfx90a:xnack+")
-else()
-  set(DEFAULT_AMDGPU_TARGETS "gfx900;gfx906;gfx908;gfx908")
+# GPU arch targets
+set(TARGETS "gfx900;gfx906")
+if(HIP_VERSION VERSION_GREATER_EQUAL "3.7")
+  set(TARGETS "${TARGETS};gfx908")
 endif()
-set(TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+if(HIP_VERSION VERSION_GREATER_EQUAL "4.3")
+  set(TARGETS "${TARGETS};gfx90a")
+endif()
+if (HIP_VERSION VERSION_GREATER_EQUAL "5.3")
+  set(TARGETS "${TARGETS};gfx940")
+endif()
+if (HIP_VERSION VERSION_GREATER_EQUAL "5.7")
+  set(TARGETS "${TARGETS};gfx941;gfx942")
+endif()
 
-# AMD targets
 foreach(target ${TARGETS})
   list(APPEND HIP_HIPCC_FLAGS "--offload-arch=${target}")
 endforeach()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -79,7 +79,8 @@ set(MPI_HOME ${HPL_MPI_DIR})
 find_package(MPI REQUIRED)
 
 # Add some paths
-list(APPEND CMAKE_PREFIX_PATH ${ROCBLAS_PATH} ${ROCM_PATH}/lib/cmake/hip ${ROCM_PATH} )
+list(APPEND CMAKE_PREFIX_PATH ${ROCBLAS_PATH} ${ROCM_PATH} )
+list(APPEND CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip )
 
 find_library(ROCTRACER NAMES roctracer64
              PATHS ${ROCM_PATH}/lib

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -79,7 +79,7 @@ set(MPI_HOME ${HPL_MPI_DIR})
 find_package(MPI REQUIRED)
 
 # Add some paths
-list(APPEND CMAKE_PREFIX_PATH ${ROCBLAS_PATH} ${ROCM_PATH})
+list(APPEND CMAKE_PREFIX_PATH ${ROCBLAS_PATH} ${ROCM_PATH}/lib/cmake/hip ${ROCM_PATH} )
 
 find_library(ROCTRACER NAMES roctracer64
              PATHS ${ROCM_PATH}/lib

--- a/include/hpl_blas.hpp
+++ b/include/hpl_blas.hpp
@@ -32,24 +32,23 @@ extern hipStream_t    computeStream;
 extern hipStream_t    dataStream;
 
 #define CHECK_HIP_ERROR(val) hipCheck((val), #val, __FILE__, __LINE__)
-inline void hipCheck(hipError_t err,
+inline void hipCheck(hipError_t        err,
                      const char* const func,
                      const char* const file,
-                     const int line) {
-  if (err != hipSuccess) {
-    std::cerr << "HIP Runtime Error at: " << file << ":" << line
-              << std::endl;
+                     const int         line) {
+  if(err != hipSuccess) {
+    std::cerr << "HIP Runtime Error at: " << file << ":" << line << std::endl;
     std::cerr << hipGetErrorString(err) << " " << func << std::endl;
     std::exit(-1);
   }
 }
 
 #define CHECK_ROCBLAS_ERROR(val) rocBLASCheck((val), #val, __FILE__, __LINE__)
-inline void rocBLASCheck(rocblas_status err,
+inline void rocBLASCheck(rocblas_status    err,
                          const char* const func,
                          const char* const file,
-                         const int line) {
-  if (err != rocblas_status_success) {
+                         const int         line) {
+  if(err != rocblas_status_success) {
     std::cerr << "rocBLAS Reports Error at: " << file << ":" << line
               << std::endl;
     std::cerr << rocblas_status_to_string(err) << " " << func << std::endl;

--- a/include/hpl_blas.hpp
+++ b/include/hpl_blas.hpp
@@ -25,10 +25,37 @@
 #include <rocblas/rocblas.h>
 #include <roctracer.h>
 #include <roctx.h>
+#include <iostream>
 
 extern rocblas_handle handle;
 extern hipStream_t    computeStream;
 extern hipStream_t    dataStream;
+
+#define CHECK_HIP_ERROR(val) hipCheck((val), #val, __FILE__, __LINE__)
+inline void hipCheck(hipError_t err,
+                     const char* const func,
+                     const char* const file,
+                     const int line) {
+  if (err != hipSuccess) {
+    std::cerr << "HIP Runtime Error at: " << file << ":" << line
+              << std::endl;
+    std::cerr << hipGetErrorString(err) << " " << func << std::endl;
+    std::exit(-1);
+  }
+}
+
+#define CHECK_ROCBLAS_ERROR(val) rocBLASCheck((val), #val, __FILE__, __LINE__)
+inline void rocBLASCheck(rocblas_status err,
+                         const char* const func,
+                         const char* const file,
+                         const int line) {
+  if (err != rocblas_status_success) {
+    std::cerr << "rocBLAS Reports Error at: " << file << ":" << line
+              << std::endl;
+    std::cerr << rocblas_status_to_string(err) << " " << func << std::endl;
+    std::exit(-1);
+  }
+}
 
 #if __cplusplus
 extern "C" {

--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,7 @@ install_blis( )
 {
   if [ ! -d "./tpl/blis" ]; then
     mkdir -p tpl && cd tpl
-    git clone https://github.com/amd/blis --branch 4.0
+    git clone https://github.com/amd/blis --branch 4.1
     check_exit_code 2
     cd blis; ./configure --prefix=${PWD} --enable-cblas --disable-sup-handling auto;
     check_exit_code 2

--- a/scripts/mpirun_rochpl.in
+++ b/scripts/mpirun_rochpl.in
@@ -107,7 +107,7 @@ num_cpu_sockets=$(lscpu | grep Socket | awk '{print $2}')
 total_cpu_cores=$(($num_cpu_cores*$num_cpu_sockets))
 
 #Default MPI options
-mpi_args=
+mpi_args="--allow-run-as-root"
 
 #Check if using OpenMPI
 if [[ $(${mpi_bin} --version | grep "open-mpi") ]]; then

--- a/scripts/mpirun_rochpl.in
+++ b/scripts/mpirun_rochpl.in
@@ -111,7 +111,7 @@ mpi_args=
 
 #Check if using OpenMPI
 if [[ $(${mpi_bin} --version | grep "open-mpi") ]]; then
-  mpi_args+=" --map-by node:PE=${total_cpu_cores} --bind-to core:overload-allowed"
+  mpi_args+=" --map-by node --rank-by node --bind-to none "
 
   #Check if this is OpenMPI+UCX
   ompi_info=$(dirname ${mpi_bin})/ompi_info

--- a/src/HPL_InitGPU.cpp
+++ b/src/HPL_InitGPU.cpp
@@ -44,7 +44,7 @@ void HPL_InitGPU(const HPL_T_grid* GRID) {
 
   /* Find out how many GPUs are in the system and their device number */
   int deviceCount;
-  hipGetDeviceCount(&deviceCount);
+  CHECK_HIP_ERROR(hipGetDeviceCount(&deviceCount));
 
   if(deviceCount < 1) {
     if(localRank == 0)
@@ -62,7 +62,7 @@ void HPL_InitGPU(const HPL_T_grid* GRID) {
 #ifdef HPL_VERBOSE_PRINT
   if(rank < localSize) {
     hipDeviceProp_t props;
-    hipGetDeviceProperties(&props, dev);
+    CHECK_HIP_ERROR(hipGetDeviceProperties(&props, dev));
 
     printf("GPU  Binding: Process %d [(p,q)=(%d,%d)] GPU: %d, pciBusID %x \n",
            rank,
@@ -75,45 +75,45 @@ void HPL_InitGPU(const HPL_T_grid* GRID) {
 
   /* Assign device to MPI process, initialize BLAS and probe device properties
    */
-  hipSetDevice(dev);
+  CHECK_HIP_ERROR(hipSetDevice(dev));
 
-  hipStreamCreate(&computeStream);
-  hipStreamCreate(&dataStream);
+  CHECK_HIP_ERROR(hipStreamCreate(&computeStream));
+  CHECK_HIP_ERROR(hipStreamCreate(&dataStream));
 
-  hipEventCreate(swapStartEvent + HPL_LOOK_AHEAD);
-  hipEventCreate(swapStartEvent + HPL_UPD_1);
-  hipEventCreate(swapStartEvent + HPL_UPD_2);
+  CHECK_HIP_ERROR(hipEventCreate(swapStartEvent + HPL_LOOK_AHEAD));
+  CHECK_HIP_ERROR(hipEventCreate(swapStartEvent + HPL_UPD_1));
+  CHECK_HIP_ERROR(hipEventCreate(swapStartEvent + HPL_UPD_2));
 
-  hipEventCreate(update + HPL_LOOK_AHEAD);
-  hipEventCreate(update + HPL_UPD_1);
-  hipEventCreate(update + HPL_UPD_2);
+  CHECK_HIP_ERROR(hipEventCreate(update + HPL_LOOK_AHEAD));
+  CHECK_HIP_ERROR(hipEventCreate(update + HPL_UPD_1));
+  CHECK_HIP_ERROR(hipEventCreate(update + HPL_UPD_2));
 
-  hipEventCreate(dgemmStart + HPL_LOOK_AHEAD);
-  hipEventCreate(dgemmStart + HPL_UPD_1);
-  hipEventCreate(dgemmStart + HPL_UPD_2);
+  CHECK_HIP_ERROR(hipEventCreate(dgemmStart + HPL_LOOK_AHEAD));
+  CHECK_HIP_ERROR(hipEventCreate(dgemmStart + HPL_UPD_1));
+  CHECK_HIP_ERROR(hipEventCreate(dgemmStart + HPL_UPD_2));
 
-  hipEventCreate(dgemmStop + HPL_LOOK_AHEAD);
-  hipEventCreate(dgemmStop + HPL_UPD_1);
-  hipEventCreate(dgemmStop + HPL_UPD_2);
+  CHECK_HIP_ERROR(hipEventCreate(dgemmStop + HPL_LOOK_AHEAD));
+  CHECK_HIP_ERROR(hipEventCreate(dgemmStop + HPL_UPD_1));
+  CHECK_HIP_ERROR(hipEventCreate(dgemmStop + HPL_UPD_2));
 }
 
 void HPL_FreeGPU() {
-  hipEventDestroy(swapStartEvent[HPL_LOOK_AHEAD]);
-  hipEventDestroy(swapStartEvent[HPL_UPD_1]);
-  hipEventDestroy(swapStartEvent[HPL_UPD_2]);
+  CHECK_HIP_ERROR(hipEventDestroy(swapStartEvent[HPL_LOOK_AHEAD]));
+  CHECK_HIP_ERROR(hipEventDestroy(swapStartEvent[HPL_UPD_1]));
+  CHECK_HIP_ERROR(hipEventDestroy(swapStartEvent[HPL_UPD_2]));
 
-  hipEventDestroy(update[HPL_LOOK_AHEAD]);
-  hipEventDestroy(update[HPL_UPD_1]);
-  hipEventDestroy(update[HPL_UPD_2]);
+  CHECK_HIP_ERROR(hipEventDestroy(update[HPL_LOOK_AHEAD]));
+  CHECK_HIP_ERROR(hipEventDestroy(update[HPL_UPD_1]));
+  CHECK_HIP_ERROR(hipEventDestroy(update[HPL_UPD_2]));
 
-  hipEventDestroy(dgemmStart[HPL_LOOK_AHEAD]);
-  hipEventDestroy(dgemmStart[HPL_UPD_1]);
-  hipEventDestroy(dgemmStart[HPL_UPD_2]);
+  CHECK_HIP_ERROR(hipEventDestroy(dgemmStart[HPL_LOOK_AHEAD]));
+  CHECK_HIP_ERROR(hipEventDestroy(dgemmStart[HPL_UPD_1]));
+  CHECK_HIP_ERROR(hipEventDestroy(dgemmStart[HPL_UPD_2]));
 
-  hipEventDestroy(dgemmStop[HPL_LOOK_AHEAD]);
-  hipEventDestroy(dgemmStop[HPL_UPD_1]);
-  hipEventDestroy(dgemmStop[HPL_UPD_2]);
+  CHECK_HIP_ERROR(hipEventDestroy(dgemmStop[HPL_LOOK_AHEAD]));
+  CHECK_HIP_ERROR(hipEventDestroy(dgemmStop[HPL_UPD_1]));
+  CHECK_HIP_ERROR(hipEventDestroy(dgemmStop[HPL_UPD_2]));
 
-  hipStreamDestroy(dataStream);
-  hipStreamDestroy(computeStream);
+  CHECK_HIP_ERROR(hipStreamDestroy(dataStream));
+  CHECK_HIP_ERROR(hipStreamDestroy(computeStream));
 }

--- a/src/HPL_pdtest.cpp
+++ b/src/HPL_pdtest.cpp
@@ -339,11 +339,11 @@ void HPL_pdtest(HPL_T_test* TEST,
       // int id = HPL_idamax( mat.mp, Bptr, 1);
       // BnormI = Bptr[id];
       int id;
-      rocblas_idamax(handle, mat.mp, dBptr, 1, &id);
+      CHECK_ROCBLAS_ERROR(rocblas_idamax(handle, mat.mp, dBptr, 1, &id));
 
       // Note: id is in Fortran indexing
-      hipMemcpy(
-          &BnormI, dBptr + id - 1, 1 * sizeof(double), hipMemcpyDeviceToHost);
+      CHECK_HIP_ERROR(hipMemcpy(
+          &BnormI, dBptr + id - 1, 1 * sizeof(double), hipMemcpyDeviceToHost));
       BnormI = Mabs(BnormI);
     } else {
       BnormI = HPL_rzero;
@@ -370,7 +370,7 @@ void HPL_pdtest(HPL_T_test* TEST,
 
     for(int nn = 0; nn < nq; nn += nq_chunk) {
       int nb = Mmin(nq - nn, nq_chunk);
-      rocblas_dgemv(handle,
+      CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
                     rocblas_operation_none,
                     mat.mp,
                     nb,
@@ -381,17 +381,17 @@ void HPL_pdtest(HPL_T_test* TEST,
                     1,
                     &one,
                     dBptr,
-                    1);
+                    1));
     }
 
-    hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost));
   } else if(nq > 0) {
     const double one  = 1.0;
     const double zero = 0.0;
     const double mone = -1.0;
 
     int nb = Mmin(nq, nq_chunk);
-    rocblas_dgemv(handle,
+    CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
                   rocblas_operation_none,
                   mat.mp,
                   nb,
@@ -402,11 +402,11 @@ void HPL_pdtest(HPL_T_test* TEST,
                   1,
                   &zero,
                   dBptr,
-                  1);
+                  1));
 
     for(int nn = nb; nn < nq; nn += nq_chunk) {
       int nb = Mmin(nq - nn, nq_chunk);
-      rocblas_dgemv(handle,
+      CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
                     rocblas_operation_none,
                     mat.mp,
                     nb,
@@ -417,10 +417,10 @@ void HPL_pdtest(HPL_T_test* TEST,
                     1,
                     &one,
                     dBptr,
-                    1);
+                    1));
     }
 
-    hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost));
   } else {
     for(ii = 0; ii < mat.mp; ii++) Bptr[ii] = HPL_rzero;
   }
@@ -433,7 +433,7 @@ void HPL_pdtest(HPL_T_test* TEST,
   /*
    * Compute || b - A x ||_oo
    */
-  hipMemcpy(dBptr, Bptr, mat.mp * sizeof(double), hipMemcpyHostToDevice);
+  CHECK_HIP_ERROR(hipMemcpy(dBptr, Bptr, mat.mp * sizeof(double), hipMemcpyHostToDevice));
   resid0 = HPL_pdlange(GRID, HPL_NORM_I, N, 1, NB, dBptr, mat.ld);
   /*
    * Computes and displays norms, residuals ...

--- a/src/HPL_pdtest.cpp
+++ b/src/HPL_pdtest.cpp
@@ -371,20 +371,21 @@ void HPL_pdtest(HPL_T_test* TEST,
     for(int nn = 0; nn < nq; nn += nq_chunk) {
       int nb = Mmin(nq - nn, nq_chunk);
       CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
-                    rocblas_operation_none,
-                    mat.mp,
-                    nb,
-                    &mone,
-                    Mptr(mat.dA, 0, nn, mat.ld),
-                    mat.ld,
-                    Mptr(mat.dX, 0, nn, 1),
-                    1,
-                    &one,
-                    dBptr,
-                    1));
+                                        rocblas_operation_none,
+                                        mat.mp,
+                                        nb,
+                                        &mone,
+                                        Mptr(mat.dA, 0, nn, mat.ld),
+                                        mat.ld,
+                                        Mptr(mat.dX, 0, nn, 1),
+                                        1,
+                                        &one,
+                                        dBptr,
+                                        1));
     }
 
-    CHECK_HIP_ERROR(hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(
+        hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost));
   } else if(nq > 0) {
     const double one  = 1.0;
     const double zero = 0.0;
@@ -392,35 +393,36 @@ void HPL_pdtest(HPL_T_test* TEST,
 
     int nb = Mmin(nq, nq_chunk);
     CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
-                  rocblas_operation_none,
-                  mat.mp,
-                  nb,
-                  &mone,
-                  Mptr(mat.dA, 0, 0, mat.ld),
-                  mat.ld,
-                  Mptr(mat.dX, 0, 0, 1),
-                  1,
-                  &zero,
-                  dBptr,
-                  1));
+                                      rocblas_operation_none,
+                                      mat.mp,
+                                      nb,
+                                      &mone,
+                                      Mptr(mat.dA, 0, 0, mat.ld),
+                                      mat.ld,
+                                      Mptr(mat.dX, 0, 0, 1),
+                                      1,
+                                      &zero,
+                                      dBptr,
+                                      1));
 
     for(int nn = nb; nn < nq; nn += nq_chunk) {
       int nb = Mmin(nq - nn, nq_chunk);
       CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
-                    rocblas_operation_none,
-                    mat.mp,
-                    nb,
-                    &mone,
-                    Mptr(mat.dA, 0, nn, mat.ld),
-                    mat.ld,
-                    Mptr(mat.dX, 0, nn, 1),
-                    1,
-                    &one,
-                    dBptr,
-                    1));
+                                        rocblas_operation_none,
+                                        mat.mp,
+                                        nb,
+                                        &mone,
+                                        Mptr(mat.dA, 0, nn, mat.ld),
+                                        mat.ld,
+                                        Mptr(mat.dX, 0, nn, 1),
+                                        1,
+                                        &one,
+                                        dBptr,
+                                        1));
     }
 
-    CHECK_HIP_ERROR(hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(
+        hipMemcpy(Bptr, dBptr, mat.mp * sizeof(double), hipMemcpyDeviceToHost));
   } else {
     for(ii = 0; ii < mat.mp; ii++) Bptr[ii] = HPL_rzero;
   }
@@ -433,7 +435,8 @@ void HPL_pdtest(HPL_T_test* TEST,
   /*
    * Compute || b - A x ||_oo
    */
-  CHECK_HIP_ERROR(hipMemcpy(dBptr, Bptr, mat.mp * sizeof(double), hipMemcpyHostToDevice));
+  CHECK_HIP_ERROR(
+      hipMemcpy(dBptr, Bptr, mat.mp * sizeof(double), hipMemcpyHostToDevice));
   resid0 = HPL_pdlange(GRID, HPL_NORM_I, N, 1, NB, dBptr, mat.ld);
   /*
    * Computes and displays norms, residuals ...

--- a/src/auxil/HPL_dlatcpy_device.cpp
+++ b/src/auxil/HPL_dlatcpy_device.cpp
@@ -105,9 +105,10 @@ void HPL_dlatcpy_gpu(const int     M,
   if((M <= 0) || (N <= 0)) return;
 
   hipStream_t stream;
-  rocblas_get_stream(handle, &stream);
+  CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
 
   dim3 grid_size((M + TILE_DIM - 1) / TILE_DIM, (N + TILE_DIM - 1) / TILE_DIM);
   dim3 block_size(TILE_DIM, BLOCK_ROWS);
   dlatcpy_gpu<<<grid_size, block_size, 0, stream>>>(M, N, A, LDA, B, LDB);
+  CHECK_HIP_ERROR(hipGetLastError());
 }

--- a/src/matgen/HPL_pdmatgen.cpp
+++ b/src/matgen/HPL_pdmatgen.cpp
@@ -118,15 +118,18 @@ int HPL_pdmatgen(HPL_T_test* TEST,
 
   /* Create a rocBLAS handle */
   CHECK_ROCBLAS_ERROR(rocblas_create_handle(&handle));
-  CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+  CHECK_ROCBLAS_ERROR(
+      rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
   CHECK_ROCBLAS_ERROR(rocblas_set_stream(handle, computeStream));
 
   rocblas_initialize();
 
 #ifdef HPL_ROCBLAS_ALLOW_ATOMICS
-  CHECK_ROCBLAS_ERROR(rocblas_set_atomics_mode(handle, rocblas_atomics_allowed));
+  CHECK_ROCBLAS_ERROR(
+      rocblas_set_atomics_mode(handle, rocblas_atomics_allowed));
 #else
-  CHECK_ROCBLAS_ERROR(rocblas_set_atomics_mode(handle, rocblas_atomics_not_allowed));
+  CHECK_ROCBLAS_ERROR(
+      rocblas_set_atomics_mode(handle, rocblas_atomics_not_allowed));
 #endif
 
   /*

--- a/src/matgen/HPL_pdmatgen.cpp
+++ b/src/matgen/HPL_pdmatgen.cpp
@@ -117,15 +117,16 @@ int HPL_pdmatgen(HPL_T_test* TEST,
   mat->W  = nullptr;
 
   /* Create a rocBLAS handle */
-  rocblas_create_handle(&handle);
-  rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+  CHECK_ROCBLAS_ERROR(rocblas_create_handle(&handle));
+  CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+  CHECK_ROCBLAS_ERROR(rocblas_set_stream(handle, computeStream));
+
   rocblas_initialize();
-  rocblas_set_stream(handle, computeStream);
 
 #ifdef HPL_ROCBLAS_ALLOW_ATOMICS
-  rocblas_set_atomics_mode(handle, rocblas_atomics_allowed);
+  CHECK_ROCBLAS_ERROR(rocblas_set_atomics_mode(handle, rocblas_atomics_allowed));
 #else
-  rocblas_set_atomics_mode(handle, rocblas_atomics_not_allowed);
+  CHECK_ROCBLAS_ERROR(rocblas_set_atomics_mode(handle, rocblas_atomics_not_allowed));
 #endif
 
   /*
@@ -243,26 +244,26 @@ int HPL_pdmatgen(HPL_T_test* TEST,
 void HPL_pdmatfree(HPL_T_pmat* mat) {
 
   if(mat->dA) {
-    hipFree(mat->dA);
+    CHECK_HIP_ERROR(hipFree(mat->dA));
     mat->dA = nullptr;
   }
   if(mat->dX) {
-    hipFree(mat->dX);
+    CHECK_HIP_ERROR(hipFree(mat->dX));
     mat->dX = nullptr;
   }
   if(mat->dW) {
-    hipFree(mat->dW);
+    CHECK_HIP_ERROR(hipFree(mat->dW));
     mat->dW = nullptr;
   }
 
   if(mat->A) {
-    hipHostFree(mat->A);
+    CHECK_HIP_ERROR(hipHostFree(mat->A));
     mat->A = nullptr;
   }
   if(mat->W) {
-    hipHostFree(mat->W);
+    CHECK_HIP_ERROR(hipHostFree(mat->W));
     mat->W = nullptr;
   }
 
-  rocblas_destroy_handle(handle);
+  CHECK_ROCBLAS_ERROR(rocblas_destroy_handle(handle));
 }

--- a/src/matgen/HPL_pdrandmat_device.cpp
+++ b/src/matgen/HPL_pdrandmat_device.cpp
@@ -196,6 +196,6 @@ void HPL_pdrandmat(const HPL_T_grid* GRID,
                                     rjumpC,
                                     startrand,
                                     A);
-
-  hipDeviceSynchronize();
+  CHECK_HIP_ERROR(hipGetLastError());
+  CHECK_HIP_ERROR(hipDeviceSynchronize());
 }

--- a/src/panel/HPL_pdpanel_SendToDevice.cpp
+++ b/src/panel/HPL_pdpanel_SendToDevice.cpp
@@ -55,21 +55,21 @@ void HPL_pdpanel_SendToDevice(HPL_T_panel* PANEL) {
       int* dipiv_ex = PANEL->dipiv + jb;
 
       CHECK_HIP_ERROR(hipMemcpy2DAsync(dipiv,
-                       jb * sizeof(int),
-                       upiv,
-                       jb * sizeof(int),
-                       jb * sizeof(int),
-                       1,
-                       hipMemcpyHostToDevice,
-                       dataStream));
+                                       jb * sizeof(int),
+                                       upiv,
+                                       jb * sizeof(int),
+                                       jb * sizeof(int),
+                                       1,
+                                       hipMemcpyHostToDevice,
+                                       dataStream));
       CHECK_HIP_ERROR(hipMemcpy2DAsync(dipiv_ex,
-                       jb * sizeof(int),
-                       ipiv_ex,
-                       jb * sizeof(int),
-                       jb * sizeof(int),
-                       1,
-                       hipMemcpyHostToDevice,
-                       dataStream));
+                                       jb * sizeof(int),
+                                       ipiv_ex,
+                                       jb * sizeof(int),
+                                       jb * sizeof(int),
+                                       1,
+                                       hipMemcpyHostToDevice,
+                                       dataStream));
 
     } else {
 
@@ -117,44 +117,47 @@ void HPL_pdpanel_SendToDevice(HPL_T_panel* PANEL) {
       int N = Mmax(*ipA, jb);
       if(N > 0) {
         CHECK_HIP_ERROR(hipMemcpy2DAsync(dlindxA,
-                         k * sizeof(int),
-                         lindxA,
-                         k * sizeof(int),
-                         N * sizeof(int),
-                         1,
-                         hipMemcpyHostToDevice,
-                         dataStream));
+                                         k * sizeof(int),
+                                         lindxA,
+                                         k * sizeof(int),
+                                         N * sizeof(int),
+                                         1,
+                                         hipMemcpyHostToDevice,
+                                         dataStream));
         CHECK_HIP_ERROR(hipMemcpy2DAsync(dlindxAU,
-                         k * sizeof(int),
-                         lindxAU,
-                         k * sizeof(int),
-                         N * sizeof(int),
-                         1,
-                         hipMemcpyHostToDevice,
-                         dataStream));
+                                         k * sizeof(int),
+                                         lindxAU,
+                                         k * sizeof(int),
+                                         N * sizeof(int),
+                                         1,
+                                         hipMemcpyHostToDevice,
+                                         dataStream));
       }
 
-      CHECK_HIP_ERROR(hipMemcpyAsync(
-          dlindxU, lindxU, jb * sizeof(int), hipMemcpyHostToDevice, dataStream));
+      CHECK_HIP_ERROR(hipMemcpyAsync(dlindxU,
+                                     lindxU,
+                                     jb * sizeof(int),
+                                     hipMemcpyHostToDevice,
+                                     dataStream));
 
       CHECK_HIP_ERROR(hipMemcpy2DAsync(dpermU,
-                       jb * sizeof(int),
-                       permU,
-                       jb * sizeof(int),
-                       jb * sizeof(int),
-                       1,
-                       hipMemcpyHostToDevice,
-                       dataStream));
+                                       jb * sizeof(int),
+                                       permU,
+                                       jb * sizeof(int),
+                                       jb * sizeof(int),
+                                       1,
+                                       hipMemcpyHostToDevice,
+                                       dataStream));
 
       // send the ipivs along with L2 in the Bcast
       CHECK_HIP_ERROR(hipMemcpy2DAsync(dipiv,
-                       jb * sizeof(int),
-                       ipiv,
-                       jb * sizeof(int),
-                       jb * sizeof(int),
-                       1,
-                       hipMemcpyHostToDevice,
-                       dataStream));
+                                       jb * sizeof(int),
+                                       ipiv,
+                                       jb * sizeof(int),
+                                       jb * sizeof(int),
+                                       1,
+                                       hipMemcpyHostToDevice,
+                                       dataStream));
     }
   }
 
@@ -162,55 +165,55 @@ void HPL_pdpanel_SendToDevice(HPL_T_panel* PANEL) {
   if(PANEL->grid->mycol == PANEL->pcol) {
     // copy L1
     CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->dL1,
-                     jb * sizeof(double),
-                     PANEL->L1,
-                     jb * sizeof(double),
-                     jb * sizeof(double),
-                     jb,
-                     hipMemcpyHostToDevice,
-                     dataStream));
+                                     jb * sizeof(double),
+                                     PANEL->L1,
+                                     jb * sizeof(double),
+                                     jb * sizeof(double),
+                                     jb,
+                                     hipMemcpyHostToDevice,
+                                     dataStream));
 
     if(PANEL->grid->npcol > 1) { // L2 is its own array
       if(PANEL->grid->myrow == PANEL->prow) {
         CHECK_HIP_ERROR(hipMemcpy2DAsync(Mptr(PANEL->dA, 0, -jb, PANEL->dlda),
-                         PANEL->dlda * sizeof(double),
-                         Mptr(PANEL->A, 0, 0, PANEL->lda),
-                         PANEL->lda * sizeof(double),
-                         jb * sizeof(double),
-                         jb,
-                         hipMemcpyHostToDevice,
-                         dataStream));
+                                         PANEL->dlda * sizeof(double),
+                                         Mptr(PANEL->A, 0, 0, PANEL->lda),
+                                         PANEL->lda * sizeof(double),
+                                         jb * sizeof(double),
+                                         jb,
+                                         hipMemcpyHostToDevice,
+                                         dataStream));
 
         if((PANEL->mp - jb) > 0)
           CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->dL2,
-                           PANEL->dldl2 * sizeof(double),
-                           Mptr(PANEL->A, jb, 0, PANEL->lda),
-                           PANEL->lda * sizeof(double),
-                           (PANEL->mp - jb) * sizeof(double),
-                           jb,
-                           hipMemcpyHostToDevice,
-                           dataStream));
+                                           PANEL->dldl2 * sizeof(double),
+                                           Mptr(PANEL->A, jb, 0, PANEL->lda),
+                                           PANEL->lda * sizeof(double),
+                                           (PANEL->mp - jb) * sizeof(double),
+                                           jb,
+                                           hipMemcpyHostToDevice,
+                                           dataStream));
       } else {
         if((PANEL->mp) > 0)
           CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->dL2,
-                           PANEL->dldl2 * sizeof(double),
-                           Mptr(PANEL->A, 0, 0, PANEL->lda),
-                           PANEL->lda * sizeof(double),
-                           PANEL->mp * sizeof(double),
-                           jb,
-                           hipMemcpyHostToDevice,
-                           dataStream));
+                                           PANEL->dldl2 * sizeof(double),
+                                           Mptr(PANEL->A, 0, 0, PANEL->lda),
+                                           PANEL->lda * sizeof(double),
+                                           PANEL->mp * sizeof(double),
+                                           jb,
+                                           hipMemcpyHostToDevice,
+                                           dataStream));
       }
     } else {
       if(PANEL->mp > 0)
         CHECK_HIP_ERROR(hipMemcpy2DAsync(Mptr(PANEL->dA, 0, -jb, PANEL->dlda),
-                         PANEL->dlda * sizeof(double),
-                         Mptr(PANEL->A, 0, 0, PANEL->lda),
-                         PANEL->lda * sizeof(double),
-                         PANEL->mp * sizeof(double),
-                         jb,
-                         hipMemcpyHostToDevice,
-                         dataStream));
+                                         PANEL->dlda * sizeof(double),
+                                         Mptr(PANEL->A, 0, 0, PANEL->lda),
+                                         PANEL->lda * sizeof(double),
+                                         PANEL->mp * sizeof(double),
+                                         jb,
+                                         hipMemcpyHostToDevice,
+                                         dataStream));
     }
   }
 }

--- a/src/panel/HPL_pdpanel_SendToDevice.cpp
+++ b/src/panel/HPL_pdpanel_SendToDevice.cpp
@@ -54,22 +54,22 @@ void HPL_pdpanel_SendToDevice(HPL_T_panel* PANEL) {
       int* dipiv    = PANEL->dipiv;
       int* dipiv_ex = PANEL->dipiv + jb;
 
-      hipMemcpy2DAsync(dipiv,
+      CHECK_HIP_ERROR(hipMemcpy2DAsync(dipiv,
                        jb * sizeof(int),
                        upiv,
                        jb * sizeof(int),
                        jb * sizeof(int),
                        1,
                        hipMemcpyHostToDevice,
-                       dataStream);
-      hipMemcpy2DAsync(dipiv_ex,
+                       dataStream));
+      CHECK_HIP_ERROR(hipMemcpy2DAsync(dipiv_ex,
                        jb * sizeof(int),
                        ipiv_ex,
                        jb * sizeof(int),
                        jb * sizeof(int),
                        1,
                        hipMemcpyHostToDevice,
-                       dataStream);
+                       dataStream));
 
     } else {
 
@@ -116,101 +116,101 @@ void HPL_pdpanel_SendToDevice(HPL_T_panel* PANEL) {
 
       int N = Mmax(*ipA, jb);
       if(N > 0) {
-        hipMemcpy2DAsync(dlindxA,
+        CHECK_HIP_ERROR(hipMemcpy2DAsync(dlindxA,
                          k * sizeof(int),
                          lindxA,
                          k * sizeof(int),
                          N * sizeof(int),
                          1,
                          hipMemcpyHostToDevice,
-                         dataStream);
-        hipMemcpy2DAsync(dlindxAU,
+                         dataStream));
+        CHECK_HIP_ERROR(hipMemcpy2DAsync(dlindxAU,
                          k * sizeof(int),
                          lindxAU,
                          k * sizeof(int),
                          N * sizeof(int),
                          1,
                          hipMemcpyHostToDevice,
-                         dataStream);
+                         dataStream));
       }
 
-      hipMemcpyAsync(
-          dlindxU, lindxU, jb * sizeof(int), hipMemcpyHostToDevice, dataStream);
+      CHECK_HIP_ERROR(hipMemcpyAsync(
+          dlindxU, lindxU, jb * sizeof(int), hipMemcpyHostToDevice, dataStream));
 
-      hipMemcpy2DAsync(dpermU,
+      CHECK_HIP_ERROR(hipMemcpy2DAsync(dpermU,
                        jb * sizeof(int),
                        permU,
                        jb * sizeof(int),
                        jb * sizeof(int),
                        1,
                        hipMemcpyHostToDevice,
-                       dataStream);
+                       dataStream));
 
       // send the ipivs along with L2 in the Bcast
-      hipMemcpy2DAsync(dipiv,
+      CHECK_HIP_ERROR(hipMemcpy2DAsync(dipiv,
                        jb * sizeof(int),
                        ipiv,
                        jb * sizeof(int),
                        jb * sizeof(int),
                        1,
                        hipMemcpyHostToDevice,
-                       dataStream);
+                       dataStream));
     }
   }
 
   // copy A and/or L2
   if(PANEL->grid->mycol == PANEL->pcol) {
     // copy L1
-    hipMemcpy2DAsync(PANEL->dL1,
+    CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->dL1,
                      jb * sizeof(double),
                      PANEL->L1,
                      jb * sizeof(double),
                      jb * sizeof(double),
                      jb,
                      hipMemcpyHostToDevice,
-                     dataStream);
+                     dataStream));
 
     if(PANEL->grid->npcol > 1) { // L2 is its own array
       if(PANEL->grid->myrow == PANEL->prow) {
-        hipMemcpy2DAsync(Mptr(PANEL->dA, 0, -jb, PANEL->dlda),
+        CHECK_HIP_ERROR(hipMemcpy2DAsync(Mptr(PANEL->dA, 0, -jb, PANEL->dlda),
                          PANEL->dlda * sizeof(double),
                          Mptr(PANEL->A, 0, 0, PANEL->lda),
                          PANEL->lda * sizeof(double),
                          jb * sizeof(double),
                          jb,
                          hipMemcpyHostToDevice,
-                         dataStream);
+                         dataStream));
 
         if((PANEL->mp - jb) > 0)
-          hipMemcpy2DAsync(PANEL->dL2,
+          CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->dL2,
                            PANEL->dldl2 * sizeof(double),
                            Mptr(PANEL->A, jb, 0, PANEL->lda),
                            PANEL->lda * sizeof(double),
                            (PANEL->mp - jb) * sizeof(double),
                            jb,
                            hipMemcpyHostToDevice,
-                           dataStream);
+                           dataStream));
       } else {
         if((PANEL->mp) > 0)
-          hipMemcpy2DAsync(PANEL->dL2,
+          CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->dL2,
                            PANEL->dldl2 * sizeof(double),
                            Mptr(PANEL->A, 0, 0, PANEL->lda),
                            PANEL->lda * sizeof(double),
                            PANEL->mp * sizeof(double),
                            jb,
                            hipMemcpyHostToDevice,
-                           dataStream);
+                           dataStream));
       }
     } else {
       if(PANEL->mp > 0)
-        hipMemcpy2DAsync(Mptr(PANEL->dA, 0, -jb, PANEL->dlda),
+        CHECK_HIP_ERROR(hipMemcpy2DAsync(Mptr(PANEL->dA, 0, -jb, PANEL->dlda),
                          PANEL->dlda * sizeof(double),
                          Mptr(PANEL->A, 0, 0, PANEL->lda),
                          PANEL->lda * sizeof(double),
                          PANEL->mp * sizeof(double),
                          jb,
                          hipMemcpyHostToDevice,
-                         dataStream);
+                         dataStream));
     }
   }
 }

--- a/src/panel/HPL_pdpanel_SendToHost.cpp
+++ b/src/panel/HPL_pdpanel_SendToHost.cpp
@@ -18,11 +18,11 @@ void HPL_pdpanel_SendToHost(HPL_T_panel* PANEL) {
 
   if(PANEL->mp > 0)
     CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->A,
-                     PANEL->lda * sizeof(double),
-                     PANEL->dA,
-                     PANEL->dlda * sizeof(double),
-                     PANEL->mp * sizeof(double),
-                     jb,
-                     hipMemcpyDeviceToHost,
-                     dataStream));
+                                     PANEL->lda * sizeof(double),
+                                     PANEL->dA,
+                                     PANEL->dlda * sizeof(double),
+                                     PANEL->mp * sizeof(double),
+                                     jb,
+                                     hipMemcpyDeviceToHost,
+                                     dataStream));
 }

--- a/src/panel/HPL_pdpanel_SendToHost.cpp
+++ b/src/panel/HPL_pdpanel_SendToHost.cpp
@@ -17,12 +17,12 @@ void HPL_pdpanel_SendToHost(HPL_T_panel* PANEL) {
   if((PANEL->grid->mycol != PANEL->pcol) || (jb <= 0)) return;
 
   if(PANEL->mp > 0)
-    hipMemcpy2DAsync(PANEL->A,
+    CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->A,
                      PANEL->lda * sizeof(double),
                      PANEL->dA,
                      PANEL->dlda * sizeof(double),
                      PANEL->mp * sizeof(double),
                      jb,
                      hipMemcpyDeviceToHost,
-                     dataStream);
+                     dataStream));
 }

--- a/src/panel/HPL_pdpanel_free.cpp
+++ b/src/panel/HPL_pdpanel_free.cpp
@@ -37,10 +37,10 @@ int HPL_pdpanel_free(HPL_T_panel* PANEL) {
 
   if(PANEL->free_work_now == 1) {
 
-    if(PANEL->dLWORK) hipFree(PANEL->dLWORK);
-    if(PANEL->dUWORK) hipFree(PANEL->dUWORK);
-    if(PANEL->LWORK) hipHostFree(PANEL->LWORK);
-    if(PANEL->UWORK) hipHostFree(PANEL->UWORK);
+    if(PANEL->dLWORK) CHECK_HIP_ERROR(hipFree(PANEL->dLWORK));
+    if(PANEL->dUWORK) CHECK_HIP_ERROR(hipFree(PANEL->dUWORK));
+    if(PANEL->LWORK)  CHECK_HIP_ERROR(hipHostFree(PANEL->LWORK));
+    if(PANEL->UWORK)  CHECK_HIP_ERROR(hipHostFree(PANEL->UWORK));
 
     PANEL->max_lwork_size = 0;
     PANEL->max_uwork_size = 0;

--- a/src/panel/HPL_pdpanel_free.cpp
+++ b/src/panel/HPL_pdpanel_free.cpp
@@ -39,8 +39,8 @@ int HPL_pdpanel_free(HPL_T_panel* PANEL) {
 
     if(PANEL->dLWORK) CHECK_HIP_ERROR(hipFree(PANEL->dLWORK));
     if(PANEL->dUWORK) CHECK_HIP_ERROR(hipFree(PANEL->dUWORK));
-    if(PANEL->LWORK)  CHECK_HIP_ERROR(hipHostFree(PANEL->LWORK));
-    if(PANEL->UWORK)  CHECK_HIP_ERROR(hipHostFree(PANEL->UWORK));
+    if(PANEL->LWORK) CHECK_HIP_ERROR(hipHostFree(PANEL->LWORK));
+    if(PANEL->UWORK) CHECK_HIP_ERROR(hipHostFree(PANEL->UWORK));
 
     PANEL->max_lwork_size = 0;
     PANEL->max_uwork_size = 0;

--- a/src/panel/HPL_pdpanel_init.cpp
+++ b/src/panel/HPL_pdpanel_init.cpp
@@ -277,7 +277,7 @@ void HPL_pdpanel_init(HPL_T_grid*  GRID,
 
   if(PANEL->max_lwork_size < (size_t)(lwork) * sizeof(double)) {
     if(PANEL->LWORK) {
-      hipFree(PANEL->dLWORK);
+      CHECK_HIP_ERROR(hipFree(PANEL->dLWORK));
       free(PANEL->LWORK);
     }
     // size_t numbytes = (((size_t)((size_t)(lwork) * sizeof( double )) +
@@ -299,7 +299,7 @@ void HPL_pdpanel_init(HPL_T_grid*  GRID,
   }
   if(PANEL->max_uwork_size < (size_t)(uwork) * sizeof(double)) {
     if(PANEL->UWORK) {
-      hipFree(PANEL->dUWORK);
+      CHECK_HIP_ERROR(hipFree(PANEL->dUWORK));
       free(PANEL->UWORK);
     }
     // size_t numbytes = (((size_t)((size_t)(uwork) * sizeof( double )) +

--- a/src/panel/HPL_pdpanel_wait.cpp
+++ b/src/panel/HPL_pdpanel_wait.cpp
@@ -15,7 +15,7 @@ void HPL_pdpanel_Wait(HPL_T_panel* PANEL) {
   HPL_ptimer(HPL_TIMING_COPY);
 #endif
   // Wait for panel
-  hipStreamSynchronize(dataStream);
+  CHECK_HIP_ERROR(hipStreamSynchronize(dataStream));
 #ifdef HPL_DETAILED_TIMING
   HPL_ptimer(HPL_TIMING_COPY);
 #endif

--- a/src/pauxil/HPL_dlaswp00N_device.cpp
+++ b/src/pauxil/HPL_dlaswp00N_device.cpp
@@ -104,8 +104,9 @@ void HPL_dlaswp00N(const int  M,
   if((M <= 0) || (N <= 0)) return;
 
   hipStream_t stream;
-  rocblas_get_stream(handle, &stream);
+  CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
 
   int grid_size = N;
   dlaswp00N<<<grid_size, BLOCK_SIZE, 0, stream>>>(N, M, A, LDA, IPIV);
+  CHECK_HIP_ERROR(hipGetLastError());
 }

--- a/src/pauxil/HPL_dlaswp01T_device.cpp
+++ b/src/pauxil/HPL_dlaswp01T_device.cpp
@@ -128,6 +128,7 @@ void HPL_dlaswp01T(const int  M,
   dim3 block_size(TILE_DIM, BLOCK_ROWS);
   dlaswp01T<<<grid_size, block_size, 0, computeStream>>>(
       M, N, A, LDA, U, LDU, LINDXU);
+  CHECK_HIP_ERROR(hipGetLastError());
 
   /*
    * End of HPL_dlaswp01T

--- a/src/pauxil/HPL_dlaswp02T_device.cpp
+++ b/src/pauxil/HPL_dlaswp02T_device.cpp
@@ -99,7 +99,7 @@ void HPL_dlaswp02T(const int  M,
   dim3 grid_size(N);
   dim3 block_size(M);
   dlaswp02T<<<N, M, 0, computeStream>>>(M, N, A, LDA, LINDXAU, LINDXA);
-
+  CHECK_HIP_ERROR(hipGetLastError());
   /*
    * End of HPL_dlaswp02T
    */

--- a/src/pauxil/HPL_dlaswp03T_device.cpp
+++ b/src/pauxil/HPL_dlaswp03T_device.cpp
@@ -126,7 +126,7 @@ void HPL_dlaswp03T(const int  M,
   dim3 block_size(TILE_DIM, BLOCK_ROWS);
   dlaswp03T<<<grid_size, block_size, 0, computeStream>>>(
       M, N, A, LDA, W, LDW, LINDXU);
-
+  CHECK_HIP_ERROR(hipGetLastError());
   /*
    * End of HPL_dlaswp03T
    */

--- a/src/pauxil/HPL_dlaswp04T_device.cpp
+++ b/src/pauxil/HPL_dlaswp04T_device.cpp
@@ -121,7 +121,7 @@ void HPL_dlaswp04T(const int  M,
   dim3 block_size(TILE_DIM, BLOCK_ROWS);
   dlaswp04T<<<grid_size, block_size, 0, computeStream>>>(
       M, N, A, LDA, W, LDW, LINDXU);
-
+  CHECK_HIP_ERROR(hipGetLastError());
   /*
    * End of HPL_dlaswp04T
    */

--- a/src/pauxil/HPL_dlaswp10N_device.cpp
+++ b/src/pauxil/HPL_dlaswp10N_device.cpp
@@ -84,8 +84,9 @@ void HPL_dlaswp10N(const int  M,
   if((M <= 0) || (N <= 0)) return;
 
   hipStream_t stream;
-  rocblas_get_stream(handle, &stream);
+  CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
 
   dim3 grid_size((M + BLOCK_SIZE - 1) / BLOCK_SIZE);
   dlaswp10N<<<grid_size, dim3(BLOCK_SIZE), 0, stream>>>(M, N, A, LDA, IPIV);
+  CHECK_HIP_ERROR(hipGetLastError());
 }

--- a/src/pauxil/HPL_pdlange_device.cpp
+++ b/src/pauxil/HPL_pdlange_device.cpp
@@ -194,14 +194,15 @@ double HPL_pdlange(const HPL_T_grid* GRID,
       if(nq == 1) { // column vector
         int id;
         CHECK_ROCBLAS_ERROR(rocblas_idamax(handle, mp, A, 1, &id));
-        CHECK_HIP_ERROR(hipMemcpy(&v0, A + id - 1, 1 * sizeof(double), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(
+            &v0, A + id - 1, 1 * sizeof(double), hipMemcpyDeviceToHost));
       } else if(mp == 1) { // row vector
         int id;
         CHECK_ROCBLAS_ERROR(rocblas_idamax(handle, nq, A, LDA, &id));
         CHECK_HIP_ERROR(hipMemcpy(&v0,
-                  A + ((size_t)id * LDA),
-                  1 * sizeof(double),
-                  hipMemcpyDeviceToHost));
+                                  A + ((size_t)id * LDA),
+                                  1 * sizeof(double),
+                                  hipMemcpyDeviceToHost));
       } else {
         // custom reduction kernels
         CHECK_HIP_ERROR(hipMalloc(&dwork, GRID_SIZE * sizeof(double)));
@@ -214,7 +215,8 @@ double HPL_pdlange(const HPL_T_grid* GRID,
         normA_2<<<1, BLOCK_SIZE>>>(grid_size, dwork);
         CHECK_HIP_ERROR(hipGetLastError());
 
-        CHECK_HIP_ERROR(hipMemcpy(&v0, dwork, 1 * sizeof(double), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(&v0, dwork, 1 * sizeof(double), hipMemcpyDeviceToHost));
         CHECK_HIP_ERROR(hipFree(dwork));
       }
     }
@@ -235,7 +237,8 @@ double HPL_pdlange(const HPL_T_grid* GRID,
         CHECK_HIP_ERROR(hipMalloc(&dwork, nq * sizeof(double)));
         norm1<<<nq, BLOCK_SIZE>>>(nq, mp, A, LDA, dwork);
         CHECK_HIP_ERROR(hipGetLastError());
-        CHECK_HIP_ERROR(hipMemcpy(work, dwork, nq * sizeof(double), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(work, dwork, nq * sizeof(double), hipMemcpyDeviceToHost));
       }
       /*
        * Find sum of global matrix columns, store on row 0 of process grid
@@ -274,7 +277,8 @@ double HPL_pdlange(const HPL_T_grid* GRID,
         size_t grid_size = (mp + BLOCK_SIZE - 1) / BLOCK_SIZE;
         norminf<<<grid_size, BLOCK_SIZE>>>(nq, mp, A, LDA, dwork);
         CHECK_HIP_ERROR(hipGetLastError());
-        CHECK_HIP_ERROR(hipMemcpy(work, dwork, mp * sizeof(double), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(work, dwork, mp * sizeof(double), hipMemcpyDeviceToHost));
       }
 
       /*

--- a/src/pgesv/HPL_pdgesv.cpp
+++ b/src/pgesv/HPL_pdgesv.cpp
@@ -197,7 +197,8 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
       HPL_pdupdate(panel[0], HPL_LOOK_AHEAD);
 
       // when the look ahead update is finished, copy back the current panel
-      CHECK_HIP_ERROR(hipStreamWaitEvent(dataStream, update[HPL_LOOK_AHEAD], 0));
+      CHECK_HIP_ERROR(
+          hipStreamWaitEvent(dataStream, update[HPL_LOOK_AHEAD], 0));
       HPL_pdpanel_SendToHost(panel[1]);
 
       /* Queue up finishing the second section */
@@ -220,8 +221,8 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
 
       // compute the GFLOPs of the look ahead update DGEMM
       CHECK_HIP_ERROR(hipEventElapsedTime(&smallDgemmTime,
-                          dgemmStart[HPL_LOOK_AHEAD],
-                          dgemmStop[HPL_LOOK_AHEAD]));
+                                          dgemmStart[HPL_LOOK_AHEAD],
+                                          dgemmStop[HPL_LOOK_AHEAD]));
       smallDgemmGflops =
           (2.0 * mp * jb * jb) / (1000.0 * 1000.0 * smallDgemmTime);
 #endif

--- a/src/pgesv/HPL_pdgesv.cpp
+++ b/src/pgesv/HPL_pdgesv.cpp
@@ -197,7 +197,7 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
       HPL_pdupdate(panel[0], HPL_LOOK_AHEAD);
 
       // when the look ahead update is finished, copy back the current panel
-      hipStreamWaitEvent(dataStream, update[HPL_LOOK_AHEAD], 0);
+      CHECK_HIP_ERROR(hipStreamWaitEvent(dataStream, update[HPL_LOOK_AHEAD], 0));
       HPL_pdpanel_SendToHost(panel[1]);
 
       /* Queue up finishing the second section */
@@ -206,7 +206,7 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
 
 #ifdef HPL_DETAILED_TIMING
       HPL_ptimer(HPL_TIMING_UPDATE);
-      hipEventSynchronize(update[HPL_LOOK_AHEAD]);
+      CHECK_HIP_ERROR(hipEventSynchronize(update[HPL_LOOK_AHEAD]));
       HPL_ptimer(HPL_TIMING_UPDATE);
 #endif
 
@@ -219,9 +219,9 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
       const int mp   = panel[0]->mp - (curr != 0 ? jb : 0);
 
       // compute the GFLOPs of the look ahead update DGEMM
-      hipEventElapsedTime(&smallDgemmTime,
+      CHECK_HIP_ERROR(hipEventElapsedTime(&smallDgemmTime,
                           dgemmStart[HPL_LOOK_AHEAD],
-                          dgemmStop[HPL_LOOK_AHEAD]);
+                          dgemmStop[HPL_LOOK_AHEAD]));
       smallDgemmGflops =
           (2.0 * mp * jb * jb) / (1000.0 * 1000.0 * smallDgemmTime);
 #endif
@@ -283,7 +283,7 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
 #ifdef HPL_DETAILED_TIMING
     HPL_ptimer(HPL_TIMING_UPDATE);
 #endif
-    hipDeviceSynchronize();
+    CHECK_HIP_ERROR(hipDeviceSynchronize());
 #ifdef HPL_DETAILED_TIMING
     HPL_ptimer(HPL_TIMING_UPDATE);
 #endif
@@ -298,14 +298,14 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
     largeDgemm1Time = 0.0;
     largeDgemm2Time = 0.0;
     if(panel[0]->nu1) {
-      hipEventElapsedTime(
-          &largeDgemm1Time, dgemmStart[HPL_UPD_1], dgemmStop[HPL_UPD_1]);
+      CHECK_HIP_ERROR(hipEventElapsedTime(
+          &largeDgemm1Time, dgemmStart[HPL_UPD_1], dgemmStop[HPL_UPD_1]));
       largeDgemm1Gflops = (2.0 * mp * jb * (panel[0]->nu1)) /
                           (1000.0 * 1000.0 * (largeDgemm1Time));
     }
     if(panel[0]->nu2) {
-      hipEventElapsedTime(
-          &largeDgemm2Time, dgemmStart[HPL_UPD_2], dgemmStop[HPL_UPD_2]);
+      CHECK_HIP_ERROR(hipEventElapsedTime(
+          &largeDgemm2Time, dgemmStart[HPL_UPD_2], dgemmStop[HPL_UPD_2]));
       largeDgemm2Gflops = (2.0 * mp * jb * (panel[0]->nu2)) /
                           (1000.0 * 1000.0 * (largeDgemm2Time));
     }
@@ -393,7 +393,7 @@ void HPL_pdgesv(HPL_T_grid* GRID, HPL_T_palg* ALGO, HPL_T_pmat* A) {
 #ifdef HPL_DETAILED_TIMING
   HPL_ptimer(HPL_TIMING_UPDATE);
 #endif
-  hipDeviceSynchronize();
+  CHECK_HIP_ERROR(hipDeviceSynchronize());
 #ifdef HPL_DETAILED_TIMING
   HPL_ptimer(HPL_TIMING_UPDATE);
 #endif

--- a/src/pgesv/HPL_pdlaswp.cpp
+++ b/src/pgesv/HPL_pdlaswp.cpp
@@ -137,16 +137,16 @@ void HPL_pdlaswp_start(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
   {
     // get the ipivs on the host after the Bcast
     if(PANEL->grid->mycol != PANEL->pcol) {
-      hipMemcpy2DAsync(PANEL->ipiv,
+      CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->ipiv,
                        PANEL->jb * sizeof(int),
                        PANEL->dipiv,
                        PANEL->jb * sizeof(int),
                        PANEL->jb * sizeof(int),
                        1,
                        hipMemcpyDeviceToHost,
-                       dataStream);
+                       dataStream));
     }
-    hipStreamSynchronize(dataStream);
+    CHECK_HIP_ERROR(hipStreamSynchronize(dataStream));
 
     // compute spreading info
     HPL_pipid(PANEL, ipl, ipID);
@@ -177,7 +177,7 @@ void HPL_pdlaswp_start(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
   }
 
   // record when packing completes
-  hipEventRecord(swapStartEvent[UPD], computeStream);
+  CHECK_HIP_ERROR(hipEventRecord(swapStartEvent[UPD], computeStream));
 
   /*
    * End of HPL_pdlaswp_start
@@ -340,7 +340,7 @@ void HPL_pdlaswp_exchange(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
 #endif
 
     // hipStreamSynchronize(computeStream);
-    hipEventSynchronize(swapStartEvent[UPD]);
+    CHECK_HIP_ERROR(hipEventSynchronize(swapStartEvent[UPD]));
 
 #ifdef HPL_DETAILED_TIMING
     HPL_ptimer(HPL_TIMING_UPDATE);
@@ -365,7 +365,7 @@ void HPL_pdlaswp_exchange(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
 
     // wait for dU to be ready
     // hipStreamSynchronize(computeStream);
-    hipEventSynchronize(swapStartEvent[UPD]);
+    CHECK_HIP_ERROR(hipEventSynchronize(swapStartEvent[UPD]));
 
 #ifdef HPL_DETAILED_TIMING
     HPL_ptimer(HPL_TIMING_UPDATE);

--- a/src/pgesv/HPL_pdlaswp.cpp
+++ b/src/pgesv/HPL_pdlaswp.cpp
@@ -138,13 +138,13 @@ void HPL_pdlaswp_start(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
     // get the ipivs on the host after the Bcast
     if(PANEL->grid->mycol != PANEL->pcol) {
       CHECK_HIP_ERROR(hipMemcpy2DAsync(PANEL->ipiv,
-                       PANEL->jb * sizeof(int),
-                       PANEL->dipiv,
-                       PANEL->jb * sizeof(int),
-                       PANEL->jb * sizeof(int),
-                       1,
-                       hipMemcpyDeviceToHost,
-                       dataStream));
+                                       PANEL->jb * sizeof(int),
+                                       PANEL->dipiv,
+                                       PANEL->jb * sizeof(int),
+                                       PANEL->jb * sizeof(int),
+                                       1,
+                                       hipMemcpyDeviceToHost,
+                                       dataStream));
     }
     CHECK_HIP_ERROR(hipStreamSynchronize(dataStream));
 

--- a/src/pgesv/HPL_pdtrsv_device.cpp
+++ b/src/pgesv/HPL_pdtrsv_device.cpp
@@ -129,7 +129,8 @@ void HPL_pdtrsv(HPL_T_grid* GRID, HPL_T_pmat* AMAT) {
   if(Anp > 0) {
     if(Alcol != Bcol) {
       if(mycol == Bcol) {
-        CHECK_HIP_ERROR(hipMemcpyAsync(dXC, dB, Anp * sizeof(double), hipMemcpyDeviceToDevice, stream));
+        CHECK_HIP_ERROR(hipMemcpyAsync(
+            dXC, dB, Anp * sizeof(double), hipMemcpyDeviceToDevice, stream));
         CHECK_HIP_ERROR(hipStreamSynchronize(stream));
         (void)HPL_send(dXC, Anp, Alcol, Rmsgid, Rcomm);
       } else if(mycol == Alcol) {
@@ -137,7 +138,8 @@ void HPL_pdtrsv(HPL_T_grid* GRID, HPL_T_pmat* AMAT) {
       }
     } else {
       if(mycol == Bcol) {
-        CHECK_HIP_ERROR(hipMemcpyAsync(dXC, dB, Anp * sizeof(double), hipMemcpyDeviceToDevice, stream));
+        CHECK_HIP_ERROR(hipMemcpyAsync(
+            dXC, dB, Anp * sizeof(double), hipMemcpyDeviceToDevice, stream));
       }
     }
   }
@@ -172,14 +174,14 @@ void HPL_pdtrsv(HPL_T_grid* GRID, HPL_T_pmat* AMAT) {
     dXdprev = (dXd = dXR + Anq);
     if(myrow == Alrow) {
       CHECK_ROCBLAS_ERROR(rocblas_dtrsv(handle,
-                    rocblas_fill_upper,
-                    rocblas_operation_none,
-                    rocblas_diagonal_non_unit,
-                    kb,
-                    dAptr + Anp,
-                    lda,
-                    dXC + Anp,
-                    1));
+                                        rocblas_fill_upper,
+                                        rocblas_operation_none,
+                                        rocblas_diagonal_non_unit,
+                                        kb,
+                                        dAptr + Anp,
+                                        lda,
+                                        dXC + Anp,
+                                        1));
       CHECK_ROCBLAS_ERROR(rocblas_dcopy(handle, kb, dXC + Anp, 1, dXd, 1));
     }
   }
@@ -236,17 +238,17 @@ void HPL_pdtrsv(HPL_T_grid* GRID, HPL_T_pmat* AMAT) {
         const double one  = 1.0;
         const double mone = -1.0;
         CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
-                      rocblas_operation_none,
-                      n1pprev,
-                      kbprev,
-                      &mone,
-                      dAprev + tmp1,
-                      lda,
-                      dXdprev,
-                      1,
-                      &one,
-                      dXC + tmp1,
-                      1));
+                                          rocblas_operation_none,
+                                          n1pprev,
+                                          kbprev,
+                                          &mone,
+                                          dAprev + tmp1,
+                                          lda,
+                                          dXdprev,
+                                          1,
+                                          &one,
+                                          dXC + tmp1,
+                                          1));
         if(GridIsNotPx1) {
           if(n1pprev) {
             CHECK_HIP_ERROR(hipDeviceSynchronize());
@@ -284,15 +286,16 @@ void HPL_pdtrsv(HPL_T_grid* GRID, HPL_T_pmat* AMAT) {
      */
     if((mycol == Alcol) && (myrow == Alrow)) {
       CHECK_ROCBLAS_ERROR(rocblas_dtrsv(handle,
-                    rocblas_fill_upper,
-                    rocblas_operation_none,
-                    rocblas_diagonal_non_unit,
-                    kb,
-                    dAptr + Anp,
-                    lda,
-                    dXC + Anp,
-                    1));
-      CHECK_ROCBLAS_ERROR(rocblas_dcopy(handle, kb, dXC + Anp, 1, dXR + Anq, 1));
+                                        rocblas_fill_upper,
+                                        rocblas_operation_none,
+                                        rocblas_diagonal_non_unit,
+                                        kb,
+                                        dAptr + Anp,
+                                        lda,
+                                        dXC + Anp,
+                                        1));
+      CHECK_ROCBLAS_ERROR(
+          rocblas_dcopy(handle, kb, dXC + Anp, 1, dXR + Anq, 1));
     }
     /*
      *  Finish previous update
@@ -301,17 +304,17 @@ void HPL_pdtrsv(HPL_T_grid* GRID, HPL_T_pmat* AMAT) {
       const double one  = 1.0;
       const double mone = -1.0;
       CHECK_ROCBLAS_ERROR(rocblas_dgemv(handle,
-                    rocblas_operation_none,
-                    tmp1,
-                    kbprev,
-                    &mone,
-                    dAprev,
-                    lda,
-                    dXdprev,
-                    1,
-                    &one,
-                    dXC,
-                    1));
+                                        rocblas_operation_none,
+                                        tmp1,
+                                        kbprev,
+                                        &mone,
+                                        dAprev,
+                                        lda,
+                                        dXdprev,
+                                        1,
+                                        &one,
+                                        dXC,
+                                        1));
     }
     /*
      *  Save info of current step and update info for the next step

--- a/src/pgesv/HPL_pdupdateNT.cpp
+++ b/src/pgesv/HPL_pdupdateNT.cpp
@@ -93,17 +93,17 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
      * 1 x Q case
      */
     CHECK_ROCBLAS_ERROR(rocblas_dtrsm(handle,
-                  rocblas_side_left,
-                  rocblas_fill_lower,
-                  rocblas_operation_none,
-                  rocblas_diagonal_unit,
-                  jb,
-                  n,
-                  &one,
-                  L1ptr,
-                  jb,
-                  Aptr,
-                  lda));
+                                      rocblas_side_left,
+                                      rocblas_fill_lower,
+                                      rocblas_operation_none,
+                                      rocblas_diagonal_unit,
+                                      jb,
+                                      n,
+                                      &one,
+                                      L1ptr,
+                                      jb,
+                                      Aptr,
+                                      lda));
 
     HPL_dlatcpy_gpu(n, jb, Aptr, lda, Uptr, LDU);
   } else {
@@ -111,17 +111,17 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
      * Compute redundantly row block of U and update trailing submatrix
      */
     CHECK_ROCBLAS_ERROR(rocblas_dtrsm(handle,
-                  rocblas_side_right,
-                  rocblas_fill_lower,
-                  rocblas_operation_transpose,
-                  rocblas_diagonal_unit,
-                  n,
-                  jb,
-                  &one,
-                  L1ptr,
-                  jb,
-                  Uptr,
-                  LDU));
+                                      rocblas_side_right,
+                                      rocblas_fill_lower,
+                                      rocblas_operation_transpose,
+                                      rocblas_diagonal_unit,
+                                      n,
+                                      jb,
+                                      &one,
+                                      L1ptr,
+                                      jb,
+                                      Uptr,
+                                      LDU));
   }
 
   /*
@@ -130,38 +130,38 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
   if(curr != 0) {
     CHECK_HIP_ERROR(hipEventRecord(dgemmStart[UPD], stream));
     CHECK_ROCBLAS_ERROR(rocblas_dgemm(handle,
-                  rocblas_operation_none,
-                  rocblas_operation_transpose,
-                  mp,
-                  n,
-                  jb,
-                  &mone,
-                  L2ptr,
-                  ldl2,
-                  Uptr,
-                  LDU,
-                  &one,
-                  Mptr(Aptr, jb, 0, lda),
-                  lda));
+                                      rocblas_operation_none,
+                                      rocblas_operation_transpose,
+                                      mp,
+                                      n,
+                                      jb,
+                                      &mone,
+                                      L2ptr,
+                                      ldl2,
+                                      Uptr,
+                                      LDU,
+                                      &one,
+                                      Mptr(Aptr, jb, 0, lda),
+                                      lda));
     CHECK_HIP_ERROR(hipEventRecord(dgemmStop[UPD], stream));
 
     if(PANEL->grid->nprow > 1) HPL_dlatcpy_gpu(jb, n, Uptr, LDU, Aptr, lda);
   } else {
     CHECK_HIP_ERROR(hipEventRecord(dgemmStart[UPD], stream));
     CHECK_ROCBLAS_ERROR(rocblas_dgemm(handle,
-                  rocblas_operation_none,
-                  rocblas_operation_transpose,
-                  mp,
-                  n,
-                  jb,
-                  &mone,
-                  L2ptr,
-                  ldl2,
-                  Uptr,
-                  LDU,
-                  &one,
-                  Aptr,
-                  lda));
+                                      rocblas_operation_none,
+                                      rocblas_operation_transpose,
+                                      mp,
+                                      n,
+                                      jb,
+                                      &mone,
+                                      L2ptr,
+                                      ldl2,
+                                      Uptr,
+                                      LDU,
+                                      &one,
+                                      Aptr,
+                                      lda));
     CHECK_HIP_ERROR(hipEventRecord(dgemmStop[UPD], stream));
   }
 

--- a/src/pgesv/HPL_pdupdateNT.cpp
+++ b/src/pgesv/HPL_pdupdateNT.cpp
@@ -74,7 +74,7 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
   if((n <= 0) || (jb <= 0)) { return; }
 
   hipStream_t stream;
-  rocblas_get_stream(handle, &stream);
+  CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
 
   curr  = (PANEL->grid->myrow == PANEL->prow ? 1 : 0);
   L2ptr = PANEL->dL2;
@@ -92,7 +92,7 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
     /*
      * 1 x Q case
      */
-    rocblas_dtrsm(handle,
+    CHECK_ROCBLAS_ERROR(rocblas_dtrsm(handle,
                   rocblas_side_left,
                   rocblas_fill_lower,
                   rocblas_operation_none,
@@ -103,14 +103,14 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
                   L1ptr,
                   jb,
                   Aptr,
-                  lda);
+                  lda));
 
     HPL_dlatcpy_gpu(n, jb, Aptr, lda, Uptr, LDU);
   } else {
     /*
      * Compute redundantly row block of U and update trailing submatrix
      */
-    rocblas_dtrsm(handle,
+    CHECK_ROCBLAS_ERROR(rocblas_dtrsm(handle,
                   rocblas_side_right,
                   rocblas_fill_lower,
                   rocblas_operation_transpose,
@@ -121,15 +121,15 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
                   L1ptr,
                   jb,
                   Uptr,
-                  LDU);
+                  LDU));
   }
 
   /*
    * Queue finishing the update
    */
   if(curr != 0) {
-    hipEventRecord(dgemmStart[UPD], stream);
-    rocblas_dgemm(handle,
+    CHECK_HIP_ERROR(hipEventRecord(dgemmStart[UPD], stream));
+    CHECK_ROCBLAS_ERROR(rocblas_dgemm(handle,
                   rocblas_operation_none,
                   rocblas_operation_transpose,
                   mp,
@@ -142,13 +142,13 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
                   LDU,
                   &one,
                   Mptr(Aptr, jb, 0, lda),
-                  lda);
-    hipEventRecord(dgemmStop[UPD], stream);
+                  lda));
+    CHECK_HIP_ERROR(hipEventRecord(dgemmStop[UPD], stream));
 
     if(PANEL->grid->nprow > 1) HPL_dlatcpy_gpu(jb, n, Uptr, LDU, Aptr, lda);
   } else {
-    hipEventRecord(dgemmStart[UPD], stream);
-    rocblas_dgemm(handle,
+    CHECK_HIP_ERROR(hipEventRecord(dgemmStart[UPD], stream));
+    CHECK_ROCBLAS_ERROR(rocblas_dgemm(handle,
                   rocblas_operation_none,
                   rocblas_operation_transpose,
                   mp,
@@ -161,9 +161,9 @@ void HPL_pdupdateNT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
                   LDU,
                   &one,
                   Aptr,
-                  lda);
-    hipEventRecord(dgemmStop[UPD], stream);
+                  lda));
+    CHECK_HIP_ERROR(hipEventRecord(dgemmStop[UPD], stream));
   }
 
-  hipEventRecord(update[UPD], stream);
+  CHECK_HIP_ERROR(hipEventRecord(update[UPD], stream));
 }

--- a/src/pgesv/HPL_pdupdateTT.cpp
+++ b/src/pgesv/HPL_pdupdateTT.cpp
@@ -93,34 +93,34 @@ void HPL_pdupdateTT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
      * 1 x Q case
      */
     CHECK_ROCBLAS_ERROR(rocblas_dtrsm(handle,
-                  rocblas_side_left,
-                  rocblas_fill_upper,
-                  rocblas_operation_transpose,
-                  rocblas_diagonal_unit,
-                  jb,
-                  n,
-                  &one,
-                  L1ptr,
-                  jb,
-                  Aptr,
-                  lda));
+                                      rocblas_side_left,
+                                      rocblas_fill_upper,
+                                      rocblas_operation_transpose,
+                                      rocblas_diagonal_unit,
+                                      jb,
+                                      n,
+                                      &one,
+                                      L1ptr,
+                                      jb,
+                                      Aptr,
+                                      lda));
     HPL_dlatcpy_gpu(n, jb, Aptr, lda, Uptr, LDU);
   } else {
     /*
      * Compute redundantly row block of U and update trailing submatrix
      */
     CHECK_ROCBLAS_ERROR(rocblas_dtrsm(handle,
-                  rocblas_side_right,
-                  rocblas_fill_upper,
-                  rocblas_operation_none,
-                  rocblas_diagonal_unit,
-                  n,
-                  jb,
-                  &one,
-                  L1ptr,
-                  jb,
-                  Uptr,
-                  LDU));
+                                      rocblas_side_right,
+                                      rocblas_fill_upper,
+                                      rocblas_operation_none,
+                                      rocblas_diagonal_unit,
+                                      n,
+                                      jb,
+                                      &one,
+                                      L1ptr,
+                                      jb,
+                                      Uptr,
+                                      LDU));
   }
 
   /*
@@ -129,38 +129,38 @@ void HPL_pdupdateTT(HPL_T_panel* PANEL, const HPL_T_UPD UPD) {
   if(curr != 0) {
     CHECK_HIP_ERROR(hipEventRecord(dgemmStart[UPD], stream));
     CHECK_ROCBLAS_ERROR(rocblas_dgemm(handle,
-                  rocblas_operation_none,
-                  rocblas_operation_transpose,
-                  mp,
-                  n,
-                  jb,
-                  &mone,
-                  L2ptr,
-                  ldl2,
-                  Uptr,
-                  LDU,
-                  &one,
-                  Mptr(Aptr, jb, 0, lda),
-                  lda));
+                                      rocblas_operation_none,
+                                      rocblas_operation_transpose,
+                                      mp,
+                                      n,
+                                      jb,
+                                      &mone,
+                                      L2ptr,
+                                      ldl2,
+                                      Uptr,
+                                      LDU,
+                                      &one,
+                                      Mptr(Aptr, jb, 0, lda),
+                                      lda));
     CHECK_HIP_ERROR(hipEventRecord(dgemmStop[UPD], stream));
 
     if(PANEL->grid->nprow > 1) HPL_dlatcpy_gpu(jb, n, Uptr, LDU, Aptr, lda);
   } else {
     CHECK_HIP_ERROR(hipEventRecord(dgemmStart[UPD], stream));
     CHECK_ROCBLAS_ERROR(rocblas_dgemm(handle,
-                  rocblas_operation_none,
-                  rocblas_operation_transpose,
-                  mp,
-                  n,
-                  jb,
-                  &mone,
-                  L2ptr,
-                  ldl2,
-                  Uptr,
-                  LDU,
-                  &one,
-                  Aptr,
-                  lda));
+                                      rocblas_operation_none,
+                                      rocblas_operation_transpose,
+                                      mp,
+                                      n,
+                                      jb,
+                                      &mone,
+                                      L2ptr,
+                                      ldl2,
+                                      Uptr,
+                                      LDU,
+                                      &one,
+                                      Aptr,
+                                      lda));
     CHECK_HIP_ERROR(hipEventRecord(dgemmStop[UPD], stream));
   }
 


### PR DESCRIPTION
Currently, using ROCmMathLibrariesBot/rocHPL:ci/openmpi fails in the OMPI CI due to switching to ROCm 6.x docker image in the CI runs.